### PR TITLE
upgrade to KotlinX 1.0.0-RC2 and force outputVariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ open classes should be avoided.
 implementation("de.brudaswen.kotlinx.serialization:kotlinx-serialization-csv:1.0.0")
 
 // Kotlin Serialization is added automatically, but can be added to force a specific version
-implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.0.0-RC")
+implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.0.0-RC2")
 ```
 
 ## Usage
@@ -100,7 +100,7 @@ CSV serialization and parsing options can be changed by providing a custom `CsvC
 
 | Dependency             | Versions |
 |---                     |---       |
-| *Kotlin Serialization* | 1.0.0-RC |
+| *Kotlin Serialization* | 1.0.0-RC2 |
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("io.codearte.nexus-staging") version "0.22.0"
 }
 
-val serializationVersion = "1.0.0-RC"
+val serializationVersion = "1.0.0-RC2"
 
 allprojects {
     group = "de.brudaswen.kotlinx.serialization"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
 
 java {
     withSourcesJar()
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {


### PR DESCRIPTION
hi @brudaswen - recently ran into this problem with some internal projects and now seeing this with kotlinx-serialization-csv also, trying to use it in an older project that still has requirements for source compatibility with 1.8 results in the following gradle error:

```
- Variant 'apiElements' capability de.brudaswen.kotlinx.serialization:kotlinx-serialization-csv:1.0.0 declares an API of a library, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm':
           - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
```

we can see that the output variant for JVM version is pinned to 11 (surmise you're building with JDK11):

```
~/develop/kotlinx-serialization-csv  ‹upgrade_to_koxsrc2*› $ ./gradlew :library:outgoingVariant

> Task :library:outgoingVariants
--------------------------------------------------
Variant apiElements
--------------------------------------------------
Description = API elements for main.

Capabilities
    - de.brudaswen.kotlinx.serialization:library:1.0.1-SNAPSHOT (default capability)
Attributes
    - org.gradle.category                 = library
    - org.gradle.dependency.bundling      = external
    - org.gradle.jvm.version              = 11
```

I did notice that you are setting the Kotlin compiler's jvmTarget to `1.8`, it looks like your intention is for it to be compatible with JDK1.8. Making the change in this PR will set the output variant correctly:

```
~/develop/kotlinx-serialization-csv  ‹upgrade_to_koxsrc2*› $ ./gradlew :library:outgoingVariant


> Task :library:outgoingVariants
--------------------------------------------------
Variant apiElements
--------------------------------------------------
Description = API elements for main.

Capabilities
    - de.brudaswen.kotlinx.serialization:library:1.0.1-SNAPSHOT (default capability)
Attributes
    - org.gradle.category                 = library
    - org.gradle.dependency.bundling      = external
    - org.gradle.jvm.version              = 8
```

Is this something you would consider to make this excellent library compatible with a wider range of projects?