### PR TITLE
Replace junit jupiter to kotest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.9.20"
-junit-jupiter = "5.11.0"
+kotest = "5.0.2"
 kotlin = "2.1.0"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization-core = "1.7.3"
@@ -9,11 +9,13 @@ nexus-staging = "0.30.0"
 researchgate-release = "3.0.2"
 
 [libraries]
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+kotest-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization-core" }
 
 [plugins]
+kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 nexus-publish = { id = "de.marcphilipp.nexus-publish", version.ref = "nexus-publish" }
 nexus-staging = { id = "io.codearte.nexus-staging", version.ref = "nexus-staging" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,6 +3,7 @@ import java.time.Duration
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
+    alias(libs.plugins.kotest.multiplatform)
     alias(libs.plugins.dokka)
     alias(libs.plugins.nexus.publish)
     `maven-publish`
@@ -14,7 +15,8 @@ dependencies {
     api(libs.kotlinx.serialization.core)
 
     testImplementation(kotlin("test-junit5"))
-    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotest.engine)
+    testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotlinx.coroutines.test)
 }
 

--- a/library/src/test/kotlin/kotlinx/serialization/csv/config/CsvBuilderTest.kt
+++ b/library/src/test/kotlin/kotlinx/serialization/csv/config/CsvBuilderTest.kt
@@ -1,13 +1,13 @@
 package kotlinx.serialization.csv.config
 
-import org.junit.jupiter.api.assertThrows
+import io.kotest.assertions.throwables.shouldThrow
 import kotlin.test.Test
 
 class CsvBuilderTest {
 
     @Test
     fun `should fail if delimiter equals quoteChar`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 delimiter = '!'
                 quoteChar = '!'
@@ -17,7 +17,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if delimiter equals escapeChar`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 delimiter = '!'
                 escapeChar = '!'
@@ -27,7 +27,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if escapeChar not set`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 quoteMode = QuoteMode.NONE
                 escapeChar = null
@@ -37,7 +37,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if recordSeparator is empty`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 recordSeparator = ""
             }.build()
@@ -46,7 +46,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if recordSeparator is too long`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 recordSeparator = "\r\n\n"
             }.build()
@@ -55,7 +55,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if recordSeparator is delimiter`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 delimiter = ','
                 recordSeparator = ","
@@ -65,7 +65,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if recordSeparator is quoteChar`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 quoteChar = '"'
                 recordSeparator = "\""
@@ -75,7 +75,7 @@ class CsvBuilderTest {
 
     @Test
     fun `should fail if recordSeparator is escapeChar`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             CsvBuilder().apply {
                 escapeChar = '\\'
                 recordSeparator = "\\"

--- a/library/src/test/kotlin/kotlinx/serialization/csv/formats/DefaultTest.kt
+++ b/library/src/test/kotlin/kotlinx/serialization/csv/formats/DefaultTest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.csv.Csv
 import kotlinx.serialization.csv.configure
 import kotlinx.serialization.csv.records.Location
 import kotlinx.serialization.test.assertDecode
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 @OptIn(ExperimentalSerializationApi::class)
 class DefaultTest {

--- a/library/src/test/kotlin/kotlinx/serialization/csv/formats/Rfc4180Test.kt
+++ b/library/src/test/kotlin/kotlinx/serialization/csv/formats/Rfc4180Test.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.csv.Csv
 import kotlinx.serialization.csv.configure
 import kotlinx.serialization.csv.records.Location
 import kotlinx.serialization.test.assertDecode
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 @OptIn(ExperimentalSerializationApi::class)
 class Rfc4180Test {

--- a/library/src/test/kotlin/kotlinx/serialization/csv/records/CsvObjectTest.kt
+++ b/library/src/test/kotlin/kotlinx/serialization/csv/records/CsvObjectTest.kt
@@ -1,11 +1,11 @@
 package kotlinx.serialization.csv.records
 
+import io.kotest.assertions.throwables.shouldThrow
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.csv.Csv
 import kotlinx.serialization.test.assertEncodeAndDecode
-import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 
 /**
@@ -43,7 +43,7 @@ class CsvObjectTest {
 
     @Test
     fun testInvalidObject() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             Csv.decodeFromString(
                 ObjectRecord.serializer(),
                 "kotlinx.serialization.csv.records.InvalidName"


### PR DESCRIPTION
## Background

I wanted to migrate your wonderful library to KMP.
To do this, I first need to migrate the dependencies that can only be used with the JVM to a Multiplatform-enabled library. In this project, that would be the `junit jupiter`.

So I replaced it with kotest, a modern Multiplatform-compatible test library in this PR.